### PR TITLE
fix product image link on top #46

### DIFF
--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -13,7 +13,9 @@
   <div class="row">
     <% @items.each do |item| %>
       <div class="col-3">
-        <%= attachment_image_tag item, :image, class: "img-fluid" %>
+        <%= link_to item_path(item) do %>
+          <%= attachment_image_tag item, :image, class: "img-fluid" %>
+        <% end %>
         <%= item.name %>
         <%= "¥#{item.price}" %>
       </div>


### PR DESCRIPTION
why
TOP画面の商品画像に詳細画面へのリンクを追加する

what
ビューの修正