### PR TITLE
fix to redirect to admin sign in when admin sign out#48

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::Base
+  def after_sign_out_path_for(resource_or_scope)
+    if resource_or_scope == :admin
+      new_admin_session_path
+    else
+      root_path
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,7 @@
                   <%= link_to "会員一覧", admin_customers_path, class: "nav-link text-dark" %>
                 </li>
                 <li class="nav-item">
-                  <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: "nav-link text-dark" %>
+                  <%= link_to "ログアウト", destroy_admin_session_path, method: :delete, class: "nav-link text-dark" %>
                 </li>
               <% else %>
                 <li class="nav-item">


### PR DESCRIPTION
why
ログアウト時、管理者ログイン画面にリダイレクトされるようにする。

what
ビューの修正
after_sign_out_path_forメソッドをオーバーライドする