### PR TITLE
fixed a bug that you can log in with a withdrawn account

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -15,6 +15,7 @@ class Public::CustomersController < ApplicationController
   def withdraw
     @customer = current_customer
     if @customer.update(is_active: false)
+      reset_session
       redirect_to root_path
     end
   end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -14,4 +14,8 @@ class Customer < ApplicationRecord
     end
     return total
   end
+
+  def active_for_authentication?
+    super && is_active
+  end
 end


### PR DESCRIPTION
why
退会済みユーザーでログインできてしまう不具合修正のため
退会処理後にセッションを破棄するため

what
customerモデルに会員アクティブ判定メソッドを追加
customersControllerのwithdrawアクションにreset_sessionを追加