### PR TITLE
fix a bug order input btn is active when cart is empty#52

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -58,6 +58,6 @@
     </div>
   </div>
   <div class="row justify-content-center">
-    <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success" %>
+    <%= link_to "情報入力に進む", new_order_path, class: "btn btn-success#{' disabled' unless @cart_items.present?}" %>
   </div>
 </div>


### PR DESCRIPTION
why
カートが空のときに情報入力ボタンを非アクティブ化する

what
cart_items/index の修正