### PR TITLE
add function customer info edit#54

### DIFF
--- a/app/controllers/public/customers_controller.rb
+++ b/app/controllers/public/customers_controller.rb
@@ -8,6 +8,13 @@ class Public::CustomersController < ApplicationController
     @customer = current_customer
   end
 
+  def update
+    @customer = current_customer
+    if @customer.update(customer_params)
+      redirect_to customers_path
+    end
+  end
+
   def unsubscribe
     @customer = current_customer
   end
@@ -18,5 +25,12 @@ class Public::CustomersController < ApplicationController
       reset_session
       redirect_to root_path
     end
+  end
+
+  private
+
+  def customer_params
+    params.require(:customer).permit(
+      :last_name, :first_name, :last_name_kana, :first_name_kana, :postal_code, :address, :telephone_number, :email)
   end
 end

--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,6 +1,6 @@
 class Public::RegistrationsController < Devise::RegistrationsController
   before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_account_update_params, only: [:update]
 
   def new
     super
@@ -15,6 +15,12 @@ class Public::RegistrationsController < Devise::RegistrationsController
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(
       :sign_up,
-      keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_code, :address, :telephone_number])
+      keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_code, :address, :telephone_number, :email])
+  end
+
+  def configure_account_update_params
+    devise_parameter_sanitizer.permit(
+      :account_update,
+      keys: [:last_name, :first_name, :last_name_kana, :first_name_kana, :postal_code, :address, :telephone_number, :email])
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -2,7 +2,7 @@ class Customer < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+        :rememberable, :validatable
 
   has_many :orders, dependent: :destroy
   has_many :cart_items, dependent: :destroy


### PR DESCRIPTION
why
会員情報編集機能の実装

what
customersControllerにupdateアクションを追加
customer_params を追加
registrationsControllerに conficure_account_update_params を追加
customerモデルから recoverable を削除(メールアドレス保存に失敗するため)